### PR TITLE
Fixed docker setup for embeds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,12 @@ services:
       #LOG_SQL: 0 (1 for verbose SQL logs)
       THREADS:
     volumes:
+      - client:/opt/app/client:ro
       - "${MOUNT_DATA}:/data"
       - "./server/config.yaml:/opt/app/config.yaml"
+    ## Expose this port if you want embeds.
+    #ports:
+    #    - "${PORT_SERVER}:6666"
 
   client:
     image: szurubooru/client:latest
@@ -34,6 +38,7 @@ services:
       BACKEND_HOST: server
       BASE_URL:
     volumes:
+      - client:/var/www
       - "${MOUNT_DATA}:/data:ro"
     ports:
       - "${PORT}:80"
@@ -46,3 +51,6 @@ services:
       POSTGRES_PASSWORD:
     volumes:
       - "${MOUNT_SQL}:/var/lib/postgresql/data"
+
+volumes:
+  client:

--- a/server/config.yaml.dist
+++ b/server/config.yaml.dist
@@ -172,11 +172,16 @@ privileges:
 homepage_url: https://www.example.com/
 site_url: https://www.example.com/booru
 
+## Client folder sharing, required for embeds.
+# Docker requires you to share /var/www from the client to the server.
+client_dir: /opt/app/client
+
 ## ONLY SET THESE IF DEPLOYING OUTSIDE OF DOCKER
 #debug: 0 # generate server logs?
 #show_sql: 0 # show sql in server logs?
 #data_url: /data/
 #data_dir: /var/www/data
+#client_dir: /var/www
 ## usage: schema://user:password@host:port/database_name
 ## example: postgres://szuru:dog@localhost:5432/szuru_test
 #database:


### PR DESCRIPTION
Fixing the docker setup by exposing the clients' `/var/www` dir to the server.
Building it locally it runs fine the first run so it should work, but if `index.htm` somehow doesn't exist when the server starts up it will require a restart, not a big deal I'd say though.

![embeds](https://github.com/user-attachments/assets/7f424995-2cf4-4749-ad4f-8de5c2ee96d6)
Tested it on a server running behind HAProxy (that routes based on Discordbot's user agent).

To get it to actually build you'll have to pull master in this branch due to the Dockerfile changes there.
Note that I didn't test running it locally without docker, but I assume the `client_dir` changes work.