### PR TITLE
server: Add required dependencies to Dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -30,9 +30,24 @@ RUN apk --no-cache add \
         gallery_dl \
         "pyheif==0.6.1" \
         "heif-image-plugin>=0.3.2" \
-        youtube_dl \
+        yt-dlp \
         "pillow-avif-plugin>=1.1.0" \
  && apk --no-cache del py3-pip
+
+# build and install mozjpeg
+RUN apk --no-cache add automake cmake nasm libpng-dev libpng curl
+RUN curl -fL "https://github.com/mozilla/mozjpeg/archive/refs/tags/v4.1.1.tar.gz" -o mozjpeg.tar.gz
+RUN tar xzf mozjpeg.tar.gz && cd mozjpeg-* \
+&& cmake -DCMAKE_INSTALL_PREFIX=/usr \
+	-DCMAKE_INSTALL_LIBDIR=/usr/lib \
+	-DBUILD_SHARED_LIBS=True \	
+	-DCMAKE_BUILD_TYPE=None \
+	-DCMAKE_C_FLAGS="$CFLAGS" \
+	-DWITH_JPEG8=1 \
+	-DWITH_TURBOJPEG=1 \
+	-DENABLE_STATIC=0 \
+&& make install && cd
+RUN apk --no-cache del automake nasm cmake curl
 
 COPY ./ /opt/app/
 RUN rm -rf /opt/app/szurubooru/tests

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -13,4 +13,4 @@ pyRFC3339>=1.0
 pytz>=2018.3
 pyyaml>=3.11
 SQLAlchemy>=1.0.12, <1.4
-youtube_dl
+yt-dlp


### PR DESCRIPTION
Resubmitting because the user who made #1 deleted their account and Github won't let me reopen the PR.

> Tried out this fork because it seems to add some decent improvements to szurubooru, but some changes broke the Docker installation.
The issues came from using [yt-dlp](https://github.com/po5/szurubooru/commit/2ec5710a38535286d294c36c3104e3cf5ee9943b) and [mozjpeg](https://github.com/po5/szurubooru/commit/69a7cac05db97c2ea4f3514d5bf8226e1b1ac72c) but not updating the Dockerfile.
I'm sure there are better ways of installing mozjpeg than compiling it in the Dockerfile, but this is my first time modifying Dockerfiles and mozjpeg isn't in Alpine Linux repos, due to it being declined: https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/39703.
Thanks for the great changes to szurubooru.

TODO: `exporter` binary from [ruffle](https://github.com/ruffle-rs/ruffle), used for swf thumbnails.